### PR TITLE
Add block shortcode for callouts

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -58,3 +58,47 @@ input[type="search"]::placeholder {
 #community a {
     color: #121314 !important;
 }
+
+.td-content blockquote.callout-success { 
+  background: #f3f8f3;
+  border-left: 6px solid #50af51;
+  padding: 1.33rem;
+}
+
+.td-content blockquote.callout-warning { 
+  background: #fcf8f2;
+  border-left: 6px solid #f0ad4e;
+  padding: 1.33rem;
+}
+
+.td-content blockquote.callout-info { 
+  background: #e3edf2;
+  border-left: 6px solid #5bc0de;
+  padding: 1.33rem;
+}
+
+.td-content blockquote.callout-danger { 
+  background: #fdf7f7;
+  border-left: 6px solid #d9534f;
+  padding: 1.33rem;
+}
+
+.callout-title-info { 
+  display: inline;
+  color: #46b8da;
+}
+
+.callout-title-warning { 
+  display: inline;
+  color: #eea236;
+}
+
+.callout-title-danger { 
+  display: inline;
+  color: #d43f3a;
+}
+
+.callout-title-success { 
+  display: inline;
+  color: #489e49;
+}

--- a/content/en/docs/Commands.md
+++ b/content/en/docs/Commands.md
@@ -170,9 +170,9 @@ Runs in the `test` profile.
 
 ## get-deps
 
-## ! Not Required !
-
-	 Unlike rebar2 this command is not required for fetching dependencies. The compile command will result in dependencies being fetched and then built if they aren't already. This command is useful if you have a specific use case that requires fetching dependencies separate from compilation. 
+{{< blocks/callout type="warning" title="Not Required">}}
+ Unlike rebar2 this command is not required for fetching dependencies. The compile command will result in dependencies being fetched and then built if they aren't already. This command is useful if you have a specific use case that requires fetching dependencies separate from compilation. 
+{{< /blocks/callout >}}
 
 Fetch project dependencies.
 

--- a/content/en/docs/Configuration.md
+++ b/content/en/docs/Configuration.md
@@ -7,9 +7,7 @@ excerpt: ""
 
 Rebar3 supports some options that will impact the behaviour of the tool wholesale. Those are defined as OS environment variables, as follows:
 
-
-
-	 REBAR_PROFILE="term"         # force a base profile
+	REBAR_PROFILE="term"         # force a base profile
 	HEX_CDN="https://..."        # change the Hex endpoint for a private one
 	REBAR_CONFIG="rebar3.config" # changes the name of rebar.config files
 	QUIET=1                      # only display errors
@@ -21,37 +19,38 @@ Rebar3 supports some options that will impact the behaviour of the tool wholesal
 	http_proxy                   # standard proxy ENV variable is respected
 	https_proxy                  # standard proxy ENV variable is respected
 
-
 ## Alias
 
 Aliases allow to create new commands out of existing ones, as if they were run one after the other:
 
 	 {alias, [{check, [eunit, {ct, "--sys_config=config/app.config"}]}]}.
+
 Arguments (as with a command line) can be passed by replacing `Provider` with `{Provider, Args}`.
 
 ## Artifacts
 
 Artifacts are a list of files that are required to exist after a successful compilation (including any compile hooks) other than Erlang modules. This is useful to let `rebar3` figure out if a dependency with some non-Erlang artifacts was successfully built or not. Examples where this can be useful include identifying C code built for shared libraries, rendered templates, or that an escript was properly generated.
 
-
-
 If a dependency is found to already be built (meaning its `.app` file's list of modules matches its `.beam` files and all its artifacts exist) it will not have the compilation provider or its hooks called on it during a subsequent run of `rebar3`.
 
 	 {artifacts, [file:filename_all()]}.
+
 What the paths are relative to depends on if it is defined at the top level of an umbrella project or not. For example, let's say we have a project `my_project` that contains an application `my_app` under `apps/my_app/` that we build an `escript` from. Then we want to tell `rebar3` to not consider the configuration in `my_project/rebar.config`, since it is the top level `rebar.config` of an umbrella. The `artifact` will be relative to the `profile_dir`, which by default is `_build/default/`:
 
-	 {escript_name, rebar3}.
+	{escript_name, rebar3}.
 
 	{provider_hooks, [{post, [{compile, escriptize}]}]}.
 
 	{artifacts, ["bin/rebar3"]}.
+
 If instead it isn't an umbrella but with `my_app` being the top level directory the artifact defined in `rebar.config` is relative to the application's output directory, in this case `_build/default/lib/my_app/` but we can use a template to define it from `profile_dir` as well:
 
-	 {escript_name, rebar3}.
+	{escript_name, rebar3}.
 
 	{provider_hooks, [{post, [{compile, escriptize}]}]}.
 
 	{artifacts, ["{{profile_dir}}/bin/rebar3"]}.
+
 All available template key are listed in the table below.
 
 | Template Key | Description                                                                             |
@@ -68,6 +67,7 @@ One more example would be using artifacts within an override, in this case for `
 	                        ...
 	                       ]
 	  }]}.
+
 The artifact is define on the application `eleveldb` so it is relative to the output directory, meaning the path used above is the same as if we used `"{{out_dir}}/priv/eleveldb.so"`.
 
 ## Compilation
@@ -88,6 +88,7 @@ Additionally it is possible to set platform specific options. The options run a 
 	              {platform_define, "^R13",
 	                'old_inets'}]
 	}.
+
 The version string might look like `"22.0-x86_64-apple-darwin18.5.0-64"` so if you want to check for a specific OTP version (and avoid matching against an OS version), remember to prefix your regular expression with `^`.
 
 A separate compile option is one to declare modules to compile before all others:
@@ -96,12 +97,13 @@ A separate compile option is one to declare modules to compile before all others
 
 And some other general options exist:
 
-	 {validate_app_modules, true}. % Make sure modules in .app match those found in code
+	{validate_app_modules, true}. % Make sure modules in .app match those found in code
 	{app_vars_file, undefined | Path}. % file containing elements to put in all generated app files
 	%% Paths the compiler outputs when reporting warnings or errors
 	%% relative (default), build (all paths are in _build, default prior
 	%% to 3.2.0, and absolute are valid options
 	{compiler_source_format, relative}.
+
 Other Erlang-related compilers are supported with their own configuration options:
 
 - [Leex compiler](http://erlang.org/doc/man/leex.html) with `{xrl_opts, [...]}`
@@ -159,9 +161,10 @@ Disable recursive compiling on test and other dirs:
 
 ## Common Test
 
-	 {ct_first_files, [...]}. % {erl_first_files, ...} but for CT
+	{ct_first_files, [...]}. % {erl_first_files, ...} but for CT
 	{ct_opts, [...]}. % same as options for ct:run_test(...)
 	{ct_readable, true | false}. % disable rebar3 modifying CT output in the shell
+
 Reference of common test options for `ct_opts`: [http://www.erlang.org/doc/man/ct.html#run_test-1](http://www.erlang.org/doc/man/ct.html#run_test-1)
 
 A special option allows to load a default `sys.config` set of entries using `{ct_opts, [{sys_config, ["name.of.config"]}]}`
@@ -174,9 +177,7 @@ Enable code coverage in [tests](doc:running-tests) with `{cover_enabled, true}`.
 
 ## Dialyzer
 
-
-
-	 -type warning() :: no_return | no_unused | no_improper_lists | no_fun_app | no_match | no_opaque | no_fail_call | no_contracts | no_behaviours | no_undefined_callbacks | unmatched_returns | error_handling | race_conditions | overspecs | underspecs | specdiffs
+	-type warning() :: no_return | no_unused | no_improper_lists | no_fun_app | no_match | no_opaque | no_fail_call | no_contracts | no_behaviours | no_undefined_callbacks | unmatched_returns | error_handling | race_conditions | overspecs | underspecs | specdiffs
 
 	{dialyzer, [{warnings, [warning()]},
 	            {get_warnings, boolean()},
@@ -198,12 +199,11 @@ Multiple providers and plugins may demand to support distributed Erlang. General
 	    {name | sname, 'nodename'},
 	]}.
 
-
 ## Directories
 
 The following options exist for directories; the value chosen below is the default value
 
-	 %% directory for artifacts produced by rebar3
+	%% directory for artifacts produced by rebar3
 	{base_dir, "_build"}.
 	%% directory in '<base_dir>/<profile>/' where deps go
 	{deps_dir, "lib"}.
@@ -224,6 +224,7 @@ The following options exist for directories; the value chosen below is the defau
 	%% relative (default), build (all paths are in _build, default prior
 	%% to 3.2.0, and absolute are valid options
 	{compiler_source_format, relative}.
+
 Furthermore, rebar3 stores some of its configuration data in `~/.config/rebar3` and cache some data in `~/.cache/rebar3`. Both can be overridden by specifying `{global_rebar_dir, "./some/path"}.`
 
 ## EDoc
@@ -245,26 +246,19 @@ Because of the structure of escript building, options at the top-level rebar.con
 
 ## EUnit
 
-
-
-	 {eunit_first_files, [...]}. % {erl_first_files, ...} but for CT
+	{eunit_first_files, [...]}. % {erl_first_files, ...} but for CT
 	{eunit_opts, [...]}. % same as options for eunit:test(Tests, ...)
 	{eunit_tests, [...]}. % same as Tests argument in eunit:test(Tests, ...)
+
 Eunit Options reference: [http://www.erlang.org/doc/man/eunit.html#test-2](http://www.erlang.org/doc/man/eunit.html#test-2)
 
 ## Hex Repos and Indexes
 
 Starting with rebar3 version 3.7.0, multiple Hex repositories (or indexes) can be used at the same time. Repositories are declared in an ordered list, from highest priority to lowest priority.
 
-
-
 When looking for a package, repositories are going to be traversed in order. As soon as one of the packages fits the description, it is downloaded. The hashes for each found packages are kept in the project's lockfile, so that if the order of repositories changes and some of them end up containing conflicting packages definitions for the same name and version pairs, only the expected one will be downloaded.
 
-
-
 This allows the same mechanism to be used for both mirrors, private repositories (as provided by hex.pm), and self-hosted indexes.
-
-
 
 For publishing or using a private repository you must use the [rebar3_hex](https://github.com/tsloughter/rebar3_hex) plugin to authenticate, `rebar3 hex auth`. This creates a separate config file `~/.config/rebar3/hex.config` storing the keys.
 
@@ -306,20 +300,15 @@ For publishing or using a private repository you must use the [rebar3_hex](https
 	   ]}
 	]}.
 
-
-
 ## Minimum OTP Version
 
 A minimum version of Erlang/OTP can be specified which causes a build to fail if an earlier version is being used to build the application.
 
 	 {minimum_otp_vsn, "17.4"}.
 
-
 ## Overrides
 
 Overrides allow to modify the configuration of a dependency from a higher level application. They are meant to allow quick fixes and workarounds, although we do recommend working on permanent fixes that make it to the target app's configuration when possible.
-
-
 
 Overrides come in 3 flavours: add, override on app and override on all.
 
@@ -330,8 +319,6 @@ Overrides come in 3 flavours: add, override on app and override on all.
 	             {del, [{atom(), any()}]},
 	             {override, [{atom(), any()}]}]}.
 These are applied to dependencies, and dependencies can have their own overrides as well that are applied. in the order overrides on all, per app overrides, per app additions.
-
-
 
 As an example, this can be used to force all the dependencies to be compiled with `debug_info` by default, and to force `no_debug_info` in case the production profile is used.
 
@@ -350,22 +337,15 @@ Another example could be to remove `warnings_as_errors` as a compiler option for
 	    {del, one_app, [{erl_opts, [warnings_as_errors]}]}
 	]}.
 
-
-## ! Overrides For All Apps in Umbrella Projects !
-
+{{< blocks/callout type="warning" title="Overrides For All Apps in Umbrella Projects">}}
 	 In an umbrella project, overrides that are specified in the top-level rebar.config file will also apply to applications within the apps/ or lib/ directory. By comparison, overrides specified in the rebar.config file at the application level will only apply to their dependencies.
-
-
+{{< /blocks/callout >}}
 
 ## Hooks
 
 There are two types of hooks: shell hooks and provider hooks. They both apply [to the same type of providers](#hookable-providers).
 
-
-
 ## Shell Hooks
-
-
 
 Hooks provide a way to run arbitrary shell commands before or after hookable providers, optionally first matching on the type of system to choose which hook to run. Shell hooks are run after provider hooks.
 
@@ -385,28 +365,20 @@ An example for building [merl](https://github.com/richcarl/merl) with rebar3 by 
 	             {"win32", eunit, "make -C \"%REBAR_DEPS_DIR%/merl\" test"}
 	            ]}.
 
-
-## ! Behaviour of post_hooks !
-
-	 A `post_hooks` entry will only be called if its hookable provider was successful. This means that if you add a `post_hooks` entry for `eunit`, it will only be called if your EUnit tests are able to finish successfully.
+{{% blocks/callout type="warning" title="Behaviour of post_hooks" %}}
+ A `post_hooks` entry will only be called if its hookable provider was successful. This means that if you add a `post_hooks` entry for `eunit`, it will only be called if your EUnit tests are able to finish successfully.
+{{% /blocks/callout %}}
 
 ## Provider Hooks
-
-
 
 Providers are also able to be used as hooks. The following hook runs `clean` before `compile` runs. To execute commands in a namespace a tuple is used as second argument. Provider hooks are run before shell hooks.
 
 	 {provider_hooks, [{pre, [{compile, clean}]}
 	                  {post, [{compile, {erlydtl, compile}}]}]}
 
-
 ## Hookable Points in Providers
 
-
-
 Only specific built-in providers support hooks attached to them. Control depends on whether the provider operates on the project's applications (each application and dependency) or if it's expected to only run on the project at large.
-
-
 
 Provider hooks are run before shell hooks.
 
@@ -426,23 +398,15 @@ Provider hooks are run before shell hooks.
 
 \* These hooks are, by default, running for every application, because dependencies may specify their own hook in their own context. The distinction is that in some cases (umbrella apps), hooks can be defined on many levels (omitting overrides):
 
-
-
 - the rebar.config file at the application root
 
 - each top-level app's (in `apps/` or `libs/`) rebar.config
 
 - each dependency's rebar.config
 
-
-
 By default, when there is no umbrella app, the hook defined in the top-level rebar.config is attributed to be part of the top-level app. This allows the hook to keep working for a dependency when the library is later published.
 
-
-
 If however the hook is defined in rebar.config at the root of a project with umbrella applications, the hooks will be run before/after the task runs for *all* of the top-level applications.
-
-
 
 To preserve the per-app behaviour in an umbrella project, hooks must instead be defined within each application's rebar.config.
 
@@ -453,8 +417,6 @@ See [Releases](doc:releases)
 ## Shell
 
 The `rebar3 shell` REPL will automatically boot applications if a `relx` entry is found, but apps to be started by the shell can be specified explicitly with `{shell, [{apps, [App]}]}`.
-
-
 
 Other options include:
 
@@ -467,9 +429,7 @@ Other options include:
 
 ## XRef
 
-
-
-	 {xref_warnings,false}.
+	{xref_warnings,false}.
 	{xref_extra_paths,[]}.
 	{xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
 	              exports_not_used,deprecated_function_calls,

--- a/content/en/docs/Custom Compiler Modules.md
+++ b/content/en/docs/Custom Compiler Modules.md
@@ -5,17 +5,17 @@ excerpt: ""
 
 This is a new feature in rebar3 3.7.0 which allows to write custom compilers to be used with Rebar3. It is useful whenever you have files of a different language that you want to build alongside Erlang resources.
 
-
-
 This interface is currently used internally for .xrl, .yrl, and .mib files, but currently few plugins have tried it.
 
-## ! This is an unstable interface !
+{{% blocks/callout type="warning" title="This is an unstable interface" %}}
 
-	 Since we have not had many plugin authors try this interface yet, it is marked as unstable and is suspect to change.
+Since we have not had many plugin authors try this interface yet, it is marked as unstable and is suspect to change.
 
 We are looking for help of contributors to further stabilize it before marking it stable. You should use this if you are willing to enter in contact with us to help iterate on the features available in [Custom Compiler Plugins](doc:custom-compiler-plugins) 
 
 It is possible that your custom compiler requires something more complex. For example, the facilities provided by this interface are insufficient to build projects that run with `mix` as a buildtool, and the plugin for that uses [a custom compiler plugin](doc:custom-compiler-plugins) 
+
+{{% /blocks/callout %}}
 
 ## Current Interface
 

--- a/content/en/docs/Custom Dep Resources.md
+++ b/content/en/docs/Custom Dep Resources.md
@@ -7,11 +7,13 @@ excerpt: ""
 
 Starting with version 3.7.0, Rebar3 published a new API for custom resources, which gives access to the project's local configuration to enable more powerful custom dependency formats. They can use contextual information from the current build to customize how dependencies might be fetched.
 
-## ! The new Interface is not backwards compatible !
+{{< blocks/callout type="warning" title="The new Interface is not backwards compatible" >}}
 
-	 This new interface is unknown and unsupported in versions prior to 3.7.0. If you are writing libraries that should work with all rebar3 copies, skip to the next section, where resources compatible with all rebar3 versions are documented.
+This new interface is unknown and unsupported in versions prior to 3.7.0. If you are writing libraries that should work with all rebar3 copies, skip to the next section, where resources compatible with all rebar3 versions are documented.
 
 Old interfaces however are still compatible with all versions and no support for existing project has been broken in adding the new API. 
+
+{{< /blocks/callout >}}
 
 The new callback API is defined as follows:
 
@@ -33,15 +35,11 @@ The new callback API is defined as follows:
 	    {plain, string()} | {error, string()}. 
 The callbacks allow the resource plugin to have access to the `rebar_state:t()` data structure, which lets you access and manipulate the [rebar3 state](https://www.rebar3.org/v3/docs/plugins#section-rebar-state-manipulation), find application state, and generally work with the [`rebar_state`](https://github.com/erlang/rebar3/blob/master/src/rebar_state.erl), [`rebar_app_info`](https://github.com/erlang/rebar3/blob/master/src/rebar_app_info.erl), [`rebar_dir`](https://github.com/erlang/rebar3/blob/master/src/rebar_dir.erl), and the new [`rebar_paths`](https://github.com/erlang/rebar3/blob/master/src/rebar_paths.erl) modules.
 
-
-
 An example of a plugin making use of this functionality is [rebar3_path_deps](https://github.com/benoitc/rebar3_path_deps). Rebar3's own [hex package resource](https://github.com/erlang/rebar3/blob/master/src/rebar_pkg_resource.erl) uses this API.
-
-
 
 A resource plugin is initialized the same way as any other plugin would:
 
-	 -module(my_rebar_plugin).
+	-module(my_rebar_plugin).
 	
 	-export([init/1]).
 	
@@ -51,11 +49,9 @@ A resource plugin is initialized the same way as any other plugin would:
 	 
 Where `Tag` stands for the type in the `deps` configuration value (`git`, `hg`, etc.), and `Module` is the callback module.
 
-
-
 The callback module may look as follows:
 
-	 -module(my_rebar_plugin_resource).
+	-module(my_rebar_plugin_resource).
 	
 	-export([init/2,
 	         lock/2,
@@ -119,15 +115,11 @@ The callback module may look as follows:
 
 Prior to version 3.7.0, the dependency resource framework was a bit more restricted. It had to essentially work context-free, with only the `deps` information from the `rebar.config` and `rebar.lock` to work from. It was not possible to have any information relative to the project configuration, which essentially restricted what could be done by each resource.
 
-
-
 These custom resources are still supported in Rebar3 versions higher than 3.7.0, and so if you have users running older build, we recommend that you develop this kind of resources only.
-
-
 
 Each dependency resource must implement the `rebar_resource` behaviour. 
 
-	 -module(rebar_resource).
+	-module(rebar_resource).
 	
 	-export_type([resource/0
 	             ,type/0
@@ -147,13 +139,12 @@ Each dependency resource must implement the `rebar_resource` behaviour.
 	    boolean().
 	-callback make_vsn(file:filename_all()) ->
 	    {plain, string()} | {error, string()}. 
+
 Included with `rebar3` are [rebar_git_resource](https://github.com/erlang/rebar3/blob/master/src/rebar_git_resource.erl), [rebar_hg_resource](https://github.com/erlang/rebar3/blob/master/src/rebar_hg_resource.erl) and [rebar_pkg_resource](https://github.com/erlang/rebar3/blob/master/src/rebar_pkg_resource.erl).
-
-
 
 A custom resource can be included the same way as a plugin. An example of this can be seen in Kelly McLaughlin's [rebar3_tidy_deps resource](https://github.com/kellymclaughlin/rebar3-tidy-deps-plugin):
 
-	 -module(rebar_tidy_deps).
+	-module(rebar_tidy_deps).
 	
 	-export([init/1]).
 	
@@ -162,18 +153,17 @@ A custom resource can be included the same way as a plugin. An example of this c
 	    {ok, rebar_state:add_resource(State, {github, rebar_github_resource})}. 
 This resource `rebar_github_resource` which implements the `rebar3` resource behaviour is added to the list of resources available in `rebar_state`. Adding the repo as a plugin to `rebar.config` allows this resource to be used:
 
-	 {mydep, {github, "kellymclauglin/mydep.git", {tag, "1.0.1"}}}.
+	{mydep, {github, "kellymclauglin/mydep.git", {tag, "1.0.1"}}}.
 	
 	{plugins, [
 	    {rebar_tidy_deps, ".*", {git, "https://github.com/kellymclaughlin/rebar3-tidy-deps-plugin.git", {tag, "0.0.2"}}}
 	]}. 
 
-
 ## Writing a Plugin working with both versions
 
 If you want to write a custom resource plugin that works with both versions, you can dynamically detect arguments to provide backwards-compatible functionality. In the example below, the new API disregards all new information and just plugs itself back in the old API:
 
-	 -module(my_rebar_plugin_resource).
+	-module(my_rebar_plugin_resource).
 	
 	-export([init/2,
 	         lock/2,
@@ -230,7 +220,5 @@ If you want to write a custom resource plugin that works with both versions, you
 	  ...
 	 
 Note that if you resource really needs the new API to work, backwards compatibility will be difficult to achieve since whenever it will be called, it won't have all the information of the new API.
-
-
 
 This approach is mostly useful when you can provide an acceptable (even if degraded) user experience with the old API.

--- a/content/en/docs/Dependencies.md
+++ b/content/en/docs/Dependencies.md
@@ -3,19 +3,15 @@ title: "Dependencies"
 excerpt: ""
 ---
 
-## ! Dependencies and Profiles !
+{{% blocks/callout type="warning" title="Dependencies and Profiles" %}}
+ Dependencies will always be compiled with the `prod` profile applied to their configuration. No other (besides `default`, of course) is used on any dependency. Even though they are configured for `prod` the dependency will still be fetched to the profile directory for the profile it is declared under. For example, a dependency in the top level `deps` will be under `_build/default/lib` and  dependency under the profile `test` will be fetched to `_build/test/lib`, and both will be compiled with their `prod` profile configuration applied. 
+{{< /blocks/callout >}}
 
-	 Dependencies will always be compiled with the `prod` profile applied to their configuration. No other (besides `default`, of course) is used on any dependency. Even though they are configured for `prod` the dependency will still be fetched to the profile directory for the profile it is declared under. For example, a dependency in the top level `deps` will be under `_build/default/lib` and  dependency under the profile `test` will be fetched to `_build/test/lib`, and both will be compiled with their `prod` profile configuration applied. 
-
-
-
-## ! Conflict Resolution !
-
-	 Unlike previous versions of rebar there is a strict set of rules for which dependencies are chosen which does not change depending on when they are fetched or updated. The algorithm for this is described below. 
+{{< blocks/callout type="warning" title="Conflict Resolution">}}
+ Unlike previous versions of rebar there is a strict set of rules for which dependencies are chosen which does not change depending on when they are fetched or updated. The algorithm for this is described below. 
+{{< /blocks/callout >}}
 
 Rebar3 considers dependency versions to be informational only. Given the existing open source landscape in the Erlang community, trying to impose [semantic versioning](http://semver.org/) or any other similar scheme is usually dead in the water: 
-
-
 
 - People update *some* versions but not all of them (git tags vs. branch names vs. OTP application versions) and they may contradict each other;
 
@@ -29,37 +25,23 @@ Rebar3 considers dependency versions to be informational only. Given the existin
 
 - Source dependencies are used in a majority at the time of this writing: figuring out version conflicts therefore requires downloading all transitive dependencies from all dependencies to figure out whether they conflict or not, every time.
 
-
-
 Any other format for dependencies would require an entire overhaul of how open source Erlang development takes place before Rebar3 gets any kind of adoption.
-
-
 
 Instead, Rebar3 will fetch and download dependencies in a level-order traversal. This means that the dependencies closest to the root of the dependency tree are those that will be chosen, regardless of their versions.
 
-
-
 This means any dependency declared in your project's `rebar.config` will never be overwritten by a transitive dependency, and a transitive dependency will never be overridden by a later encountered conflicting transitive dependency.
-
-
 
 This also means that if you prefer a version to be used above all else, you can just add it to your `rebar.config` file and pick what will be kept.
 
-
-
 After each run of dependency fetching and resolving the list of final dependencies are written to `rebar.lock`.
 
-## ! Treating Conflicts as Errors !
-
-	 If you ever want rebar3 to abort as soon as it detects a dependency conflict, instead of skipping the file and proceeding as usual, add the line `{deps_error_on_conflict, true}.` to your rebar configuration file. 
-
-
+{{< blocks/callout type="warning" title="Treating Conflicts as Errors">}}
+ If you ever want rebar3 to abort as soon as it detects a dependency conflict, instead of skipping the file and proceeding as usual, add the line `{deps_error_on_conflict, true}.` to your rebar configuration file. 
+{{< /blocks/callout >}}
 
 ## Declaring Dependencies
 
 Dependencies can be declared in a top-level `rebar.config` file, and inspected with the `rebar3 tree` command.
-
-
 
 In general, Rebar3 supports two types of dependencies:
 
@@ -67,15 +49,9 @@ In general, Rebar3 supports two types of dependencies:
 
 - Package dependencies
 
-
-
 Both of these may be handled slightly differently (packages offer more information than source dependencies before downloading them, and will be cached locally in `~/.cache/rebar3/`), but they will generally behave the same.
 
-
-
 All dependencies are to be project-local. This is usually a good choice in order avoid the common problems of global libraries having version conflicts. It also helps with the general Erlang mechanism of [Releases](doc:releases), which builds standalone systems.
-
-
 
 Dependencies fit any of the following formats:
 
@@ -99,17 +75,12 @@ Dependencies fit any of the following formats:
 	  {rebar, {git, "git://github.com/erlang/rebar3.git"}, [raw]},
 	  {rebar, "3.*", {git, "git://github.com/erlang/rebar3.git"}, [raw]}
 	]}. 
+
 As the example above shows, for the current versions, only packages, git sources, and mercurial sources are supported. Custom dependency sources can be added by [implementing the resource behaviour](doc:custom-dep-resources) and including it like a plugin.
-
-
 
 Rebar3 will fetch whatever else is required. 
 
-
-
 However, the dependency handling done by Erlang/OTP to boot and shut down applications, and tools (even part of Rebar3) to build releases and scripts, depend on a more granular dependency declaration, specifying which of each application in a project depend on others.
-
-
 
 You should add each dependency to your `app`  or `app.src` files:
 
@@ -127,13 +98,9 @@ You should add each dependency to your `app`  or `app.src` files:
 	 ]}. 
 This will allow the flexibility to write and generate software where various disjoint applications can coexist in a virtual machine without their dependencies being entirely tangled together. For example, you may want your web server to be able to run independently of administrative and debugging tools, even if they should be available in production.
 
-
-
 If more formats require support, Rebar3 can be extended via the [`rebar_resource` behaviour](https://github.com/erlang/rebar3/blob/master/src/rebar_resource.erl), and sent to the maintainers with a [pull request](https://github.com/erlang/rebar3/blob/master/CONTRIBUTING.md).
 
 ## Source Dependencies
-
-
 
 For a regular dependency tree, such as:
 
@@ -141,7 +108,6 @@ For a regular dependency tree, such as:
 	 / \
 	B   C  
 the dependencies `A`, `B`, and `C` will be fetched.
-
 
 
 However, for more complex trees, such as:
@@ -153,11 +119,7 @@ However, for more complex trees, such as:
 	C2 
 The dependencies `A`, `B`, and `C1` will be fetched. When Rebar3 will encounter the requirement for `C2`, it will instead display the warning: `Skipping C2 (from $SOURCE) as an app of the same name has already been fetched`.
 
-
-
 Such a message should let the user know which dependency has been skipped.
-
-
 
 What about cases where two transitive dependencies have the same name and are on the same level?
 
@@ -166,9 +128,8 @@ What about cases where two transitive dependencies have the same name and are on
 	B     C
 	|     |
 	D1    D2 
+
 In such a case, `D1` will take over `D2`, because `B` lexicographically sorts before `C`. It's an entirely arbitrary rule, but it is at least a rule that ensures repeatable fetches.
-
-
 
 In the event users disagree with the outcome, they can bring `D2` to the top level and ensure it will be chosen early:
 
@@ -177,13 +138,10 @@ In the event users disagree with the outcome, they can bring `D2` to the top lev
 	B     C
 	|     |
 	D1    D2 
+
 Which will yield `A`, `B`, `C`, and `D2`.
 
-
-
 Rebar3 will perform that same algorithm with packages, and will also detect circular dependencies and error out on these. However, Source dependencies *always* take precedence over packages.
-
-
 
 Dependencies in the `_checkouts` directory will be left untouched.
 
@@ -191,22 +149,20 @@ Dependencies in the `_checkouts` directory will be left untouched.
 
 Rebar3 uses [hex.pm](https://hex.pm) to provide a managed set of packages and their dependencies, which you can get a list of with the following command: 
 
-	 $ rebar3 update
+	$ rebar3 update
 	===> Updating package index...
 	$ rebar3 pkgs 
+
 A package dependency can then be included as shown earlier:
 
 	 {deps, [
 	        {cowboy, "1.0.0"}
 	       ]
 	}. 
+
 The package manager will fetch a minimal set of dependencies to comply with the build rules based on their dependency graphs, sorted topologically. To support proper behaviour with source dependencies, the set of package dependencies will be merged and handled along with source dependencies' level-order traversal. The end result to pick winners in case of conflicts will be similar to source dependencies, with warnings displayed.
 
-
-
 The main difference is that package dependencies should be much faster by virtue of being able to resolve everything with pre-computed data, make use of resources such as CDNs and local caches, and support compressed archive formats. They also are stable and do not risk changing at any moment's notice.
-
-
 
 To use a CDN other than the default, such as one of the [official mirrors](https://hex.pm/docs/mirrors) add to your project's `rebar.config` or to `~/.config/rebar3/rebar.config`:
 
@@ -217,34 +173,19 @@ To use a CDN other than the default, such as one of the [official mirrors](https
 
 To handle the case of dependencies you wish to work on locally, there is the `_checkouts` directory. Simply make a symlink or copy your dependency to `_checkouts` at the top level of your project. Any application/plugin in `_checkouts` will take precedence over the same application if it is additionally listed in the `rebar.config`'s `deps`, `plugins` or `project_plugins`. This also overrides anything 'plugins' . This also overrides anything already fetched to `_build`.
 
-
-
 Note that `_checkout` is an override, this means that for it to work an dep/plugin entry in rebar.config needs to exist
 
-
-
-
-
 Note that `_checkout` is an override, this means that for it to work an dep/plugin entry in rebar.config needs to exist
-
-
 
 	 _checkouts
 	└── depA
 	    └── src 
 
-
 ## Upgrading Dependencies
 
 Whenever a dependency is fetched and locked, Rebar3 will extract a reference from the source file to pin it to a specific version in time. The dependency should be forced to follow that version on following builds.
 
-
-
 Rebar3 allows to upgrade previously installed dependencies to newer versions. This can take two forms: forwarding a branch's reference to its latest version (e.g. an old `master` up to the new `master`'s `HEAD` for source files, or the newest versions for packages that didn't specify one), or crushing an existing locked dependency with a new version from the `rebar.config` file.
-
-
-
-
 
 In the following dependency tree:
 
@@ -254,11 +195,7 @@ In the following dependency tree:
 	 
 The user can upgrade either dependency (`rebar3 upgrade A` and `rebar3 upgrade B`) or both at once (`rebar3 upgrade A,B` or `rebar3 upgrade`, which upgrades *all* dependencies).
 
-
-
 Upgrading only `A` means that `A` and `C` may be upgraded. Upgrades to `B` and `D` will be ignored.
-
-
 
 Upgrading source dependencies is fraught with peril, though, and interesting corner cases arise. Consider the following dependency tree:
 
@@ -269,6 +206,7 @@ Upgrading source dependencies is fraught with peril, though, and interesting cor
 	  J   K
 	  |
 	  I1 
+
 After fetching the dependency tree above, `I2` would be chosen before `I1`. However, following an upgrade from `C1` to `C2` where `C2` no longer needs to depend on `I2`, Rebar3 will automatically go fetch `I1` under the `A` tree (even if no upgrade in `A` was required) to provide a correct new tree:
 
 	     A       B     C2
@@ -278,21 +216,16 @@ After fetching the dependency tree above, `I2` would be chosen before `I1`. Howe
 	  J   K
 	  |
 	  I1 
+
 Where `I2` no longer exists in the project, and `I1` now does.
 
 ## Lock Files
 
 Lock files (`rebar.lock`) are one of the only artifacts that will be generated by rebar3 that will live outside of `_build/`, and that should be checked into source control. The lock file contains information regarding code dependencies, including immutable references for source dependencies like those in git or hg, and their versions along with expected hashes for packages.
 
-
-
 The objective is to use more accurate information regarding found dependencies than what would be obtained through the config file on its own, allowing, for example, to configure a dependency to be updated from 'master', but to be locked to a stable tested version in the meanwhile. Only unlocking or upgrading the dependency will allow it to move it to a newer or different version. The idea is to allow repeatable builds, even if, for example, git tags or branches are destructively modified by someone.
 
-
-
 Rebar3 will also use the lock file as the true source of authority for dependencies when switching branches or fetching transitive deps (it will pick data from the lock file if any is available) rather than the `rebar.config` file. This allows to more easily carry a safe tested state into other applications when loose references or versions are used in the `rebar.config` file.
-
-
 
 The format is expected to be forwards and backwards compatible since version 3.0.0 (actually, beta-4). Rebar3 will annotate lock file versions according to the format of metadata stored, and warn when an old version of rebar3 is used to read a newer version of lock files. This can tell the user that some metadata that is judged important at a later date will be lost by using an older copy of the tool.
 
@@ -300,7 +233,7 @@ The format is expected to be forwards and backwards compatible since version 3.0
 
 The status of locks and dependencies can be inspected with `rebar3 deps`:
 
-	 → rebar3 deps
+	→ rebar3 deps
 	cowboy* (package)
 	recon* (git source)
 	erlware_commons (locked git source)
@@ -310,19 +243,13 @@ The status of locks and dependencies can be inspected with `rebar3 deps`:
 	 
 The dependencies are compared with the lock file to report on their status. Those whose presence on disk does not match the lock file are annotated with an asterisk (`*`).
 
-
-
 If a dependency is locked but no longer required nor in your config file, you can unmark it with `rebar3 unlock <app>` (`rebar3 unlock <app1>,<app2>,...,<app3>` for many apps).
-
-
 
 Calling `rebar3 unlock` will flush the lock file entirely.
 
-
-
 Alternatively, `rebar3 tree` can be used to display the tree of current dependencies:
 
-	 → rebar3 tree
+	→ rebar3 tree
 	...
 	|- bootstrap-0.0.2 (git repo)
 	|- dirmon-0.1.0 (project app)

--- a/content/en/docs/Plugins.md
+++ b/content/en/docs/Plugins.md
@@ -17,31 +17,25 @@ The above configuration will result in `erl_vsn` task being run before the `comp
 
 Some plugins work best if they are able to override the available commands. However, this isn't something that plugins should be able to do when the project they are included in is used as a dependency. `project_plugins` defines plugins that will only be available when the project is being built directly by `rebar3` commands, as in running `rebar3` from the top level directory of the application/project. 
 
-
-
 For example the cuttlefish plugin is only necessary when building a release, so not fetching it and having it available per application dependency makes sense. It also works best if it works the same as building a release or tarball. So when included in `project_plugins`:
 
 	 {project_plugins, [rebar3_cuttlefish]}. 
+
 Running `rebar3 release` or `rebar3 tar` will be running the `rebar3_cuttlefish` providers instead of the built in providers.
-
-
 
 Additionally there are cases you only need a plugin for development. Say you have protobufs and commit the generated modules to the repo and include in the hex package, then there is no need for the protobuf plugin to be available when the application is a dependency and is only needed for development purposes. Before `project_plugins` it was common to see a `dev` profile with plugins added under it, but this then required running `rebar3 as dev protobuf` and dealing with another profile under `_build`. With project plugins the config can instead be:
 
 	 {project_plugins, [rebar3_gpb_plugin]}. 
+
 Now we need only run `rebar3 protobuf`. We do not include any hooks because we will be committing the generated code to the repository and the plugin will not be fetched if this project is used as a dependency. 
 
 ## Upgrading Plugins
 
 Plugins work a bit like dependencies (although they are currently not being version-locked); they will not be automatically updated unless you ask for them to be.
 
-
-
 - You can upgrade project-local plugins by calling `rebar3 plugins upgrade <plugin_name>`.
 
 - You can upgrade global plugins by calling `rebar3 as global plugins upgrade <plugin_name>`, which invokes a hidden global profile used specifically to switch the upgrade context for plugins.
-
-
 
 If you are using hex packages as plugins and you do not see the version you expected, remember to use call `rebar3 update` to get a fresh Hex index. Once again, since plugins are not locked as part of the lock file, it might be a good idea to always specify a version for them.
 
@@ -82,15 +76,15 @@ If you are using hex packages as plugins and you do not see the version you expe
 For the `auto` plugin it is suggested to place the entry in the global `rebar3` config which should be made as `~/.config/rebar3/rebar.config`.
 
 	 {plugins, [rebar3_auto]}. 
+
 Running `rebar3 auto` will start the shell the same as running `rebar3 shell` but will be listening for file changes in your project's application source directories. When a file is change it will message the rebar3 agent to run compile and reload modules.
-
-
 
 ## Auto-Test
 
 For the `autotest` plugin it is suggested to place the entry in the global `rebar3` config which should be made as `~/.config/rebar3/rebar.config`.
 
 	 {plugins, [{rebar3_autotest, "0.1.1"}]}. 
+
 Running `rebar3 as test autotest` will start `eunit` once and set watches for your source, header and test-files, so that it reruns `eunit` on changes on one of the files.
 
 ## Hex Package Management
@@ -98,17 +92,16 @@ Running `rebar3 as test autotest` will start `eunit` once and set watches for yo
 For the `hex` plugin it is suggested to place the entry in the global `rebar3` config which should be made as `~/.config/rebar3/rebar.config`.
 
 	 {plugins, [rebar3_hex]}. 
+
 For usage go to the [Hex Package Management](doc:hex-package-management) section and the [Publishing Packages](doc:publishing-packages) tutorial. To view the package go to [hex.pm](https://hex.pm/packages/rebar3_hex) and to open issues [Github](https://github.com/tsloughter/rebar3_hex)
 
 ## Port Compiler
 
 This plugin is provides the old `rebar` interface to building C and C++ code to `rebar3`. The package can be found on [hex.pm](https://hex.pm/packages/pc) and issues on [Github](https://github.com/blt/port_compiler).
 
-
-
 In your project's `rebar.config` add the `pc` plugin and calls to it in `provider_hooks` for `compile` and `clean`:
 
-	 {plugins, [pc]}.
+	{plugins, [pc]}.
 	
 	{provider_hooks,
 	 [
@@ -119,10 +112,11 @@ In your project's `rebar.config` add the `pc` plugin and calls to it in `provide
 	   ]
 	  }
 	 ]
-	}. 
+	}.
+
 Configuration variables available:
 
-	 %% Supported configuration variables:
+	%% Supported configuration variables:
 	%%
 	%% * port_specs - Erlang list of tuples of the forms
 	%%                {ArchRegex, TargetFile, Sources, Options}
@@ -185,16 +179,16 @@ Configuration variables available:
 
 	 {plugins, [rebar3_run]}. 
 
-
 ## Alias
 
 The alias plugin has been added to rebar3 starting with version 3.5.0. See http://rebar3.org/v3/docs/configuration#section-alias for instructions.
 
 For prior versions, the plugin for aliasing a single command to run multiple tasks can be found at [Github](https://github.com/tsloughter/rebar_alias) and [hex.pm](https://hex.pm/packages/rebar_alias).
 
-	 {plugins, [rebar_alias]}.
+	{plugins, [rebar_alias]}.
 	
 	{alias, [{check, [eunit, {ct, "--sys_config=config/app.config"}]}]}. 
+
 Arguments (as with a command line) can be passed by replacing `Provider` with `{Provider, Args}`.
 
 ## Quickcheck
@@ -202,6 +196,7 @@ Arguments (as with a command line) can be passed by replacing `Provider` with `{
 A rebar3 plugin to enable the execution of [Erlang QuickCheck](http://www.quviq.com/products/erlang-quickcheck/) properties. Found on [Github](https://github.com/kellymclaughlin/rebar3-eqc-plugin) and [hex.pm](https://hex.pm/packages/rebar3_eqc).
 
 	 {plugins, [rebar3_eqc]}. 
+
 Config options for the Quickcheck go under `eqc_opts`, for example `{eqc_opts, [{numtests, 500}]}.`:
 
 | Config Option | Type    | Description                                                                                      |
@@ -222,19 +217,17 @@ Similarly configuration can be passed on the command line:
 
 [PropEr](http://proper.softlab.ntua.gr/) is a free alternative to Quviq Quickcheck. The plugin is available [on hex as a package](https://hex.pm/packages/rebar3_proper) or [github](https://github.com/ferd/rebar3_proper/)
 
-	 %% the plugin itself
+	%% the plugin itself
 	{plugins, [rebar3_proper]}.
-	
 	
 	%% The PropEr dependency is still required to compile the test cases
 	{profiles,
 	    [{test, [
 	        {deps, [{proper, "1.1.1-beta"}]}
 	    ]}
-	]}. 
+	]}.
+
 All of PropEr's configuration options can be passed in rebar.config under `{proper_opts, Options}` or as command line arguments:
-
-
 
 | rebar.config key          | Command Line       | Description                                                                                                                                  |
 | ------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -258,6 +251,7 @@ All of PropEr's configuration options can be passed in rebar.config under `{prop
 The [rebar3_diameter_compiler](https://github.com/carlosedp/rebar3_diameter_compiler) plugin compiles diameter .dia files in rebar3 projects.
 
 	 {plugins, [rebar3_diameter_compiler]}. 
+
 Add hooks to automatically compile and clean the diameter dictionaries:
 
 	 {provider_hooks, [
@@ -266,6 +260,7 @@ Add hooks to automatically compile and clean the diameter dictionaries:
 	        {clean, {diameter, clean}}
 	    ]}
 	]}. 
+
 Configuration options:
 
 | Config Option   | Type | Description                                                              |
@@ -282,6 +277,7 @@ The [erlydtl](https://github.com/erlydtl/erlydtl) compiler has been moved to a s
 	    {rebar3_erlydtl_plugin, ".*",
 	     {git, "https://github.com/tsloughter/rebar3_erlydtl_plugin.git", {branch, "master"}}}
 	]}. 
+
 Config options go in a list under `erlydtl_opts` in `rebar.config`:
 
 | Config Option    | Type     | Description                                                                                                                    |
@@ -298,9 +294,10 @@ Config options go in a list under `erlydtl_opts` in `rebar.config`:
 Plugin for building PEG files using [Sean Cribbs neotoma app](https://github.com/seancribbs/neotoma). This plugin is published to Hex so can be added to your project with:
 
 	 {plugins, [rebar3_neotoma_plugin]}. 
+
 The `compile` function is under the `neotoma` namespace. To automatically before the Erlang compiler add the `pre_hook` to `rebar.config`:
 
-	 {provider_hooks, [
+	{provider_hooks, [
 	    {pre, [{compile, {neotoma, compile}}]}
 	]}. 
 
@@ -310,7 +307,7 @@ The `compile` function is under the `neotoma` namespace. To automatically before
 
 [Plugin](https://github.com/lrascao/rebar3_gpb_plugin) for building .proto files using Tomas Abrahamsson's [gpb](https://github.com/tomas-abrahamsson/gpb). This plugin is published to Hex so can be added to your project with:
 
-	 {erl_opts, [{i, "./_build/default/plugins/gpb/include/"}]}.
+	{erl_opts, [{i, "./_build/default/plugins/gpb/include/"}]}.
 	{plugins, [{rebar3_gpb_plugin, "2.10.0"}]}.
 	
 	{gpb_opts, [{i, "proto"},
@@ -323,6 +320,7 @@ The `compile` function is under the `protobuf` namespace. To automatically build
 	 {provider_hooks, [
 	    {pre, [{compile, {protobuf, compile}}]}
 	]}. 
+
 Full documentation available in the plugin's [README](https://github.com/lrascao/rebar3_gpb_plugin/blob/develop/README.md#use)
 
 ## Appup
@@ -330,12 +328,14 @@ Full documentation available in the plugin's [README](https://github.com/lrascao
 Plugin for generating, compiling and validating .appup.src files. This plugin is published to Hex so can be added to your project with:
 
 	 {plugins, [rebar3_appup_plugin]}. 
+
 The `compile` and `clean` functions are under the `appup` namespace. To automatically build before the Erlang compiler add the `provider` `pre` hook to `rebar.config`:
 
 	 {provider_hooks, [
 	    {post, [{compile, {appup, compile}},
 	            {clean, {appup, clean}}]}
 	]}. 
+
 To compare two releases and generate the .appup with the necessary instructions to execute the release upgrade run:
 
 	 git checkout <from version>
@@ -363,41 +363,46 @@ Starting with rebar3 3.7.0, you can make use of [`rebar3_path_deps`](https://git
 
 Let’s start off by making a new OTP application `hello_utils` inside of your  project `hello_world`:
 
-	 # inside of hello-world/
+	# inside of hello-world/
 	$ rebar3 new app hello_utils 
- This will create a new folder `hello_utils` inside of which a `rebar.config` and `src` folder are ready to be used. 
+
+This will create a new folder `hello_utils` inside of which a `rebar.config` and `src` folder are ready to be used. 
 
 In order to tell Rebar about this, open up `hello_world/rebar.config` and add `hello_utils` to your dependencies:
 
-	 {deps, [
+	{deps, [
 	  {hello_utils, {path, "hello_utils"}},
 	  ...
 	] 
+
 This tells Rebar that we depend on an application called `hello_utils` which is found in the `hello_utils` directory (relative to the `rebar.config` file it’s written in).
 
 Then add the plugin to your `rebar.config`:
 
-	 {plugins, [
+	{plugins, [
 	   rebar3_path_deps
 	]}.
 	 
 Then just compile your application
 
-	 $ rebar3 compile
+	$ rebar3 compile
 	===> Compiling rebar3_path_deps
 	===> Verifying dependencies...
 	===> Fetching hello_utils ({path,"hello_utils",
 	                            {mtime,<<"2018-10-17T11:21:18Z">>}})
 	===> Compiling hello_utils
 	===> Compiling hello_world 
+
 This should cover it all.
 
 For versions prior to 3.7.0, the following plugin was preferable, but only worked at the top-level of a project.
 
 	 {plugins, [rebar3_vendor]}. 
-To store the fetched dependencies under `./deps/` for committing:
 
-	 rebar3 vendor store 
+To store the fetched dependencies under `./deps/` for committing:
+    
+    rebar3 vendor store 
+
 To take the vendored dependencies from `./deps/` and place them under the build directory in the appropriate place:
 
 	 rebar3 vendor apply 
@@ -414,31 +419,25 @@ Starting with Rebar3 3.7.0, Mix dependencies are supported with the [rebar_mix](
 
 Add the plugin to your rebar config:
 
-``` erlang
-
+```
 {plugins, [rebar_mix]}.
 
 {provider_hooks, [{post, [{compile, {mix, consolidate_protocols}}]}]}.
-
 ```    
 
 The `consolidate_protocols` hook places beams in `_build/<profile>/consolidated` that will need to be included in a release when built. Using:
 
-``` erlang
-
+```
 {overlay, [{copy, "{{base_dir}}/consolidated", "releases/{{release_version}}/consolidated"}]}
-
 ```
 
 And update your `vm.args.src` to include:
 
-``` erlang
-
+```
 -pa releases/${REL_VSN}/consolidated
 
 ```
 
-## ! Elixir with Older Rebar3 releases !
-
-	 For Rebar3 versions prior to 3.7.0, the [rebar3_elixir_compile](https://github.com/barrel-db/rebar3_elixir_compile) plugin was preferred, although it required manually hoisting all transitive dependencies to the project root.  plugin. Full example and configuration instructions are provided on the plugin's [README page](https://github.com/barrel-db/rebar3_elixir_compile). 
-
+{{% blocks/callout type="warning" title="Elixir with Older Rebar3 releases" %}}
+ For Rebar3 versions prior to 3.7.0, the [rebar3_elixir_compile](https://github.com/barrel-db/rebar3_elixir_compile) plugin was preferred, although it required manually hoisting all transitive dependencies to the project root.  plugin. Full example and configuration instructions are provided on the plugin's [README page](https://github.com/barrel-db/rebar3_elixir_compile). 
+{{% /blocks/callout %}}

--- a/content/en/docs/Releases.md
+++ b/content/en/docs/Releases.md
@@ -3,20 +3,19 @@ title: "Releases"
 excerpt: ""
 ---
 
-## ! What are releases and target systems anyway? !
-
-	 A release is the set of applications needed for booting an Erlang VM and starting your project. This is described through a release resource file (`.rel`) which is used to generate a `.script` and `.boot`. The boot file is the binary form of the script file and is what is used by the Erlang Run Time System (ERTS) to start an Erlang node, sort of like booting an operating system. Even running `erl` on the command line is using a boot script.
+{{% blocks/callout type="info" title="What are releases and target systems anyway?" %}}
+A release is the set of applications needed for booting an Erlang VM and starting your project. This is described through a release resource file (`.rel`) which is used to generate a `.script` and `.boot`. The boot file is the binary form of the script file and is what is used by the Erlang Run Time System (ERTS) to start an Erlang node, sort of like booting an operating system. Even running `erl` on the command line is using a boot script.
 
 A target system is an Erlang system capable of being booted on another machine (virtual or otherwise), often ERTS is bundled along with the target system.
 
 For more information checkout the [chapter on releases](http://learnyousomeerlang.com/release-is-the-word) (though it relies on reltool) from Learn You Some Erlang. 
 
+{{% /blocks/callout %}}
 
 
-## ! No Reltool !
-
-	 Reltool is out and relx is in. If you want to continue using reltool you can manually, it is still bundled with Erlang/OTP. 
-
+{{% blocks/callout type="danger" title="No Reltool" %}}
+ Reltool is out and relx is in. If you want to continue using reltool you can manually, it is still bundled with Erlang/OTP. 
+{{% /blocks/callout %}}
 
 
 ## Getting Started

--- a/content/en/docs/Workflow.md
+++ b/content/en/docs/Workflow.md
@@ -5,8 +5,6 @@ excerpt: ""
 
 If you know the basic commands, have gone through [Getting Started](doc:getting-started), [Basic Usage](doc:basic-usage), and have a brief understanding of [Releases](doc:releases), the next step is possibly to figure out a workflow for your project and your team.
 
-
-
 This section is a work in progress of various recommended steps and possible default configurations for various tasks in order to have a good experience with the Erlang toolchain.
 
 ## Pick the Right Type of Project
@@ -40,11 +38,14 @@ The basic configuration of a project should do at least two things:
 
 Tracking the lock file will let you have repeatable builds, and will allow rebar3 to do things like automatically re-update dependencies when switching branches.
 
-## ! The _build directory should be safe to delete but you shouldn't need to !
+
+{{< blocks/callout type="warning" title="The _build directory should be safe to delete but you shouldn't need to">}}
 
 	 Rebar3 tracks all the applications declared in your rebar.config files and should be able to track all required changes.
 
-There are a few edge cases where this is not possible and may lead to weird bugs, specifically when you are changing your project structure. If you are moving from a single-app project to an umbrella project (i.e. all source files move from `src/` to `apps/myapp/src`) or the opposite, there are chances that various artifacts in the _build directory will conflict with each other. Delete it and ask for a fresh build in this case. 
+    There are a few edge cases where this is not possible and may lead to weird bugs, specifically when you are changing your project structure. If you are moving from a single-app project to an umbrella project (i.e. all source files move from `src/` to `apps/myapp/src`) or the opposite, there are chances that various artifacts in the _build directory will conflict with each other. Delete it and ask for a fresh build in this case. 
+
+{{< /blocks/callout >}}
 
 The next thing you'll want to do is add dependencies to your project. See the [Dependencies](doc:dependencies) section for this. Adding dependencies does not automatically integrate them to your project, however.
 
@@ -125,17 +126,13 @@ This configuration will allow to call `rebar3 check`, which will run the followi
 
 As soon as a task fails, the whole command is interrupted. You can adapt the aliases to your needs.
 
-## ! Optimize for task delays !
-
-	 A tip to save you time is to run tasks that are short first. For example, `xref` will find some issues that `dialyzer` also finds. Running `xref` before Dialyzer in your aliases will give you a faster feedback loop 
-
-
+{{< blocks/callout type="info" title="Optimize for task delays">}}
+A tip to save you time is to run tasks that are short first. For example, `xref` will find some issues that `dialyzer` also finds. Running `xref` before Dialyzer in your aliases will give you a faster feedback loop 
+{{< /blocks/callout >}}
 
 ## Recommended Configurations for Various tools
 
 Some of the rebar3 configurations and defaults can be either too permissive or restrictive. However, due to commitments to backwards compatibility, we can't always change and adapt them since it would risk breaking projects that relied on these specific configurations.
-
-
 
 The following is a collection of a few configurations that can be useful as new defaults when starting a new project.
 

--- a/content/en/docs/tutorials/Building C-C--.md
+++ b/content/en/docs/tutorials/Building C-C--.md
@@ -3,10 +3,9 @@ title: "Building C/C++"
 excerpt: ""
 ---
 
-## ! No port compiler !
-
-	 In rebar3 it is required to have a Makefile or other instructions for building your C/C++ code outside of rebar itself. 
-
+{{< blocks/callout type="warning" title="No port compiler">}}
+In rebar3 it is required to have a Makefile or other instructions for building your C/C++ code outside of rebar itself.
+{{< /blocks/callout >}}
 
 
 ## Using the Makefile Template

--- a/content/en/docs/tutorials/Building Plugins.md
+++ b/content/en/docs/tutorials/Building Plugins.md
@@ -552,25 +552,20 @@ In other ways, a namespace acts like `do` (`rebar3 do compile, edoc`), but opera
 
 To declare a namespace, an provider needs only to use the `{namespace, Namespace}` option in its configuration list. The provider will automatically register the new namespace and be available under this term. 
 
-## ! Namespaces also apply to provider dependencies and hooks !
-
-	 If a provider is part of a given namespace, its dependencies will be searched within that same namespace. Therefore if `rebar3 mytool rebuild` depends on `compile`, the `compile` command will be looked for in the `mytool` namespace.
+{{% blocks/callout type="warning" title="Namespaces also apply to provider dependencies and hooks" %}}
+ If a provider is part of a given namespace, its dependencies will be searched within that same namespace. Therefore if `rebar3 mytool rebuild` depends on `compile`, the `compile` command will be looked for in the `mytool` namespace.
 
 To use the default `compile` command, the dependency must be declared as `{default, compile}`, or more generally `{NameSpace, Command}`.
 
 The same mechanism is applied for hooks. 
 
+{{% /blocks/callout %}}`
+
 ## Tutorial ##
-
-
 
 ### First version ###
 
-
-
 In this tutorial, we'll show how to start from scratch, and get a basic plugin written. The plugin will be quite simple: it will look for instances of 'TODO:' lines in comments and report them as warnings. The final code for the plugin can be found on [bitbucket](https://bitbucket.org/ferd/rebar3-todo-plugin).
-
-
 
 The first step is to create a new OTP Application that will contain the plugin:
 
@@ -585,8 +580,6 @@ The first step is to create a new OTP Application that will contain the plugin:
     → git init
 
     Initialized empty Git repository in /Users/ferd/code/self/todo/.git/
-
-
 
 The `src/todo.erl` file will be used to call call the initialization of all commands. For now we'll only have one `todo` command. Open up the `src/todo_prv.erl` file that will contain the command implementation, and make sure you have the following skeleton in place:
 

--- a/content/en/docs/tutorials/Publishing Packages.md
+++ b/content/en/docs/tutorials/Publishing Packages.md
@@ -2,9 +2,9 @@
 title: "Publishing Packages"
 excerpt: ""
 ---
-## ! Hex.pm account setup !
-
-	 This tutorial assumes you have followed instructions to setup and login to your [hex.pm](http://hex.pm) account. See the [Hex Package Management User subsection](doc:hex-package-management#user) for details. 
+{{% blocks/callout type="warning" title="Hex.pm account setup" %}}
+  This tutorial assumes you have followed instructions to setup and login to your [hex.pm](https://hex.pm) account. See the [Hex Package Management User subsection](doc:hex-package-management#user) for details. 
+{{% /blocks/callout %}}
 
 Metadata for a package is found in the application's specification and the dependencies found in `rebar.config`/`rebar.lock`.
 

--- a/content/en/docs/tutorials/Using Breakpoints to Debug Tests.md
+++ b/content/en/docs/tutorials/Using Breakpoints to Debug Tests.md
@@ -27,7 +27,7 @@ The problem with a debugger is that it can be really difficult to properly obser
 
 In this document, we'll see two possible patterns that can be enabled with the new breakpoints feature introduced in version 3.7.0: breakpoints to enable trace probes, and breakpoints to go poke at a critical section in some code.
 
-## ! Breakpoints are useful for many types of testing !
+{{< blocks/callout type="success" title="Breakpoints are useful for many types of testing">}}
 
 	 This page shows breakpoints used with Common Test, but they work with any provider, including plugins for QuickCheck or PropEr, out of the box.
 
@@ -35,7 +35,7 @@ If you are a plugin developer, you should also be able to use these breakpoints.
 
 This should prevent any problems where the plugin needs to run before the shell itself starts, or where a user might accidentally hang a build. 
 
-
+{{< /blocks/callout >}}
 
 ## The Base Mechanism
 

--- a/layouts/shortcodes/blocks/callout.html
+++ b/layouts/shortcodes/blocks/callout.html
@@ -1,0 +1,14 @@
+{{ $type := .Get "type" }}
+{{ $title := .Get "title" }}
+{{ $icons := (dict "warning" "🚧" "info" "📘" "danger" "❗️" "success" "👍") }}
+{{ $type_icon := index $icons $type }}
+
+<blockquote class="callout-{{ $type }}">
+  <h3>
+    <span>{{ $type_icon }}</span>
+    <p class="callout-title-{{ $type }}">{{ $title }}</p>
+  </h3>
+  <p class="callout-text-{{ $type }}">
+    {{ .Inner }}
+  </p>
+</blockquote>


### PR DESCRIPTION
Closes #2 

   - adds block shortcode for info, warning, danger and success callouts
   - remove some excess whitespace
   - fixup code block indentation

<img width="654" alt="Screen Shot 2020-07-11 at 6 25 12 PM" src="https://user-images.githubusercontent.com/39971740/87235660-eeb2c400-c3a3-11ea-8121-db1b630cd23a.png">
<img width="655" alt="Screen Shot 2020-07-11 at 6 25 00 PM" src="https://user-images.githubusercontent.com/39971740/87235662-f2dee180-c3a3-11ea-9f4e-763d12363290.png">
<img width="622" alt="Screen Shot 2020-07-11 at 6 25 30 PM" src="https://user-images.githubusercontent.com/39971740/87235664-f6726880-c3a3-11ea-9356-a415529e2841.png">




