### PR TITLE
Normalize content file names and order TOC

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Rebar3 Documentation"
 linkTitle: Documentation
-weight: 20
+weight: 0
 menu:
   main:
-    weight: 20
+    weight: 0
 description: >
   Documentation and usage guides on how to use Rebar3.
 ---

--- a/content/en/docs/basic_usage.md
+++ b/content/en/docs/basic_usage.md
@@ -1,5 +1,6 @@
 ---
 title: "Basic Usage"
+weight: 2
 excerpt: ""
 ---
 

--- a/content/en/docs/commands.md
+++ b/content/en/docs/commands.md
@@ -1,5 +1,6 @@
 ---
 title: "Commands"
+weight: 4
 excerpt: ""
 ---
 

--- a/content/en/docs/configuration.md
+++ b/content/en/docs/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: "Configuration"
 excerpt: ""
+weight: 3
 ---
 
 ## Global (all-commands) configuration

--- a/content/en/docs/custom_compiler_modules.md
+++ b/content/en/docs/custom_compiler_modules.md
@@ -1,6 +1,7 @@
 ---
 title: "Custom Compiler Modules"
 excerpt: ""
+weight: 14
 ---
 
 This is a new feature in rebar3 3.7.0 which allows to write custom compilers to be used with Rebar3. It is useful whenever you have files of a different language that you want to build alongside Erlang resources.

--- a/content/en/docs/custom_dep_resources.md
+++ b/content/en/docs/custom_dep_resources.md
@@ -1,5 +1,6 @@
 ---
 title: "Custom Dep Resources"
+weight: 6
 excerpt: ""
 ---
 

--- a/content/en/docs/dependencies.md
+++ b/content/en/docs/dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependencies"
+weight: 5
 excerpt: ""
 ---
 

--- a/content/en/docs/dynamic_configuration.md
+++ b/content/en/docs/dynamic_configuration.md
@@ -1,6 +1,7 @@
 ---
 title: "Dynamic Configuration"
 excerpt: ""
+weight: 12
 ---
 
 With `rebar.config` and `*.app.src` you can make use of dynamic configuration based on [file:script/2](http://www.erlang.org/doc/man/file.html#script-2).

--- a/content/en/docs/getting_started.md
+++ b/content/en/docs/getting_started.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+weight: 1
 excerpt: ""
 ---
 

--- a/content/en/docs/hex_package_management.md
+++ b/content/en/docs/hex_package_management.md
@@ -1,6 +1,7 @@
 ---
 title: "Hex Package Management"
 excerpt: ""
+weight: 11
 ---
 
 For package management `rebar3` uses [hex.pm](http://hex.pm), a package manager for Erlang and Elixir packages. For instructions on publishing your package see the [Publishing Packages](doc:publishing-packages) tutorial. Below is an entry for each subtask of the `hex` namespace and what it does.

--- a/content/en/docs/plugins.md
+++ b/content/en/docs/plugins.md
@@ -1,6 +1,7 @@
 ---
 title: "Plugins"
 excerpt: ""
+weight: 10
 ---
 
 Plugins can be installed locally to a project and globally. To install a plugin locally, specify it under `plugins` in your project's `rebar.config`. Globally installed plugins are configured in `~/.config/rebar3/rebar.config` and automatically installed when you use a rebar3 command in your project.

--- a/content/en/docs/profiles.md
+++ b/content/en/docs/profiles.md
@@ -1,6 +1,7 @@
 ---
 title: "Profiles"
 excerpt: ""
+weight: 7
 ---
 
 {{% blocks/callout type="warning" title="Dependencies and Profiles" %}}

--- a/content/en/docs/releases.md
+++ b/content/en/docs/releases.md
@@ -1,6 +1,7 @@
 ---
 title: "Releases"
 excerpt: ""
+weight: 9
 ---
 
 {{% blocks/callout type="info" title="What are releases and target systems anyway?" %}}

--- a/content/en/docs/running_tests.md
+++ b/content/en/docs/running_tests.md
@@ -1,6 +1,7 @@
 ---
 title: "Running Tests"
 excerpt: ""
+weight: 8
 ---
 
 Rebar3 has built in `eunit` and `ct` (`common_test`) test runners. By following a few conventions you can run test suites with a single Rebar3 command.

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Rebar3 Tutorials"
 linkTitle: Tutorials
-weight: 20
+weight: 50
 menu:
   main:
-    weight: 20
+    weight: 50
 description: >
   Tutorials on how to use Rebar3.
 ---

--- a/content/en/docs/tutorials/building_c_cpp.md
+++ b/content/en/docs/tutorials/building_c_cpp.md
@@ -1,6 +1,7 @@
 ---
 title: "Building C/C++"
 excerpt: ""
+weight: 54
 ---
 
 {{< blocks/callout type="warning" title="No port compiler">}}

--- a/content/en/docs/tutorials/building_plugins.md
+++ b/content/en/docs/tutorials/building_plugins.md
@@ -1,6 +1,7 @@
 ---
 title: "Building Plugins"
 excerpt: ""
+weight: 52
 ---
 
 Rebar3's system is based on the concept of *[providers](https://github.com/tsloughter/providers)*. A provider has three callbacks:

--- a/content/en/docs/tutorials/custom_compiler_plugins.md
+++ b/content/en/docs/tutorials/custom_compiler_plugins.md
@@ -1,6 +1,7 @@
 ---
 title: "Custom Compiler Plugins"
 excerpt: ""
+weight: 56
 ---
 
 This tutorial shows how to write plugins that provide wholesale new compilers. This is something you should use if you want to be compatible with rebar3 prior to version 3.7.0, or when your compiler requires features outside of the scope of what is provided by the compiler plugin behaviour.

--- a/content/en/docs/tutorials/from_rebar2_to_rebar3.md
+++ b/content/en/docs/tutorials/from_rebar2_to_rebar3.md
@@ -1,6 +1,7 @@
 ---
 title: "From Rebar 2.x to Rebar3"
 excerpt: ""
+weight: 55
 ---
 
 Rebar3 changes quite a few things from rebar 2.x. By and far, rebar3 attempts to keep full compatibility when handling OTP applications written in pure Erlang. People who built or wrote standard OTP apps will therefore see very few incompatibilities, although the ground still needs to be prepared.

--- a/content/en/docs/tutorials/publishing_packages.md
+++ b/content/en/docs/tutorials/publishing_packages.md
@@ -1,6 +1,7 @@
 ---
 title: "Publishing Packages"
 excerpt: ""
+weight: 51
 ---
 {{% blocks/callout type="warning" title="Hex.pm account setup" %}}
   This tutorial assumes you have followed instructions to setup and login to your [hex.pm](https://hex.pm) account. See the [Hex Package Management User subsection](doc:hex-package-management#user) for details. 

--- a/content/en/docs/tutorials/templates.md
+++ b/content/en/docs/tutorials/templates.md
@@ -1,6 +1,7 @@
 ---
 title: "Templates"
 excerpt: ""
+weight: 53
 ---
 
 - [Default Variables](#section-default-variables)

--- a/content/en/docs/tutorials/using_breakpoints_to_debug_tests.md
+++ b/content/en/docs/tutorials/using_breakpoints_to_debug_tests.md
@@ -1,6 +1,7 @@
 ---
 title: "Using Breakpoints to Debug Tests"
 excerpt: ""
+weight: 57
 ---
 
 ## The Problem

--- a/content/en/docs/workflow.md
+++ b/content/en/docs/workflow.md
@@ -1,6 +1,7 @@
 ---
 title: "Workflow"
 excerpt: ""
+weight: 13
 ---
 
 If you know the basic commands, have gone through [Getting Started](doc:getting-started), [Basic Usage](doc:basic-usage), and have a brief understanding of [Releases](doc:releases), the next step is possibly to figure out a workflow for your project and your team.


### PR DESCRIPTION
Closes #14 

    - snake case content file names
     - add weight to each content file to achieve parity with production
     site TOC order

<img width="274" alt="Screen Shot 2020-07-12 at 12 58 42 PM" src="https://user-images.githubusercontent.com/39971740/87253258-71d52800-c43f-11ea-8eb4-cb684b52d542.png">
