### PR TITLE
Clarify recursive compilation rules

### DIFF
--- a/content/en/docs/configuration.md
+++ b/content/en/docs/configuration.md
@@ -142,21 +142,25 @@ rebar3 ships with some compiler options specific to rebar3.
 
 #### Enable/Disable recursive compiling
 
-Disable or enable recusrive compiling globally
+Disable or enable recursive compiling globally:
 
 ```erlang
 {erlc_compiler,[{recursive,boolean()}]}.
 ```
 
-Disable or enable recursive compiling on src_dirs:
+Disable or enable recursive compiling on `src_dirs`:
 
 ```erlang
+{src_dirs, [{"src", [{recursive, true|false}]}]}
+%% Or alternatively:
 {erl_opts, [{src_dirs,[{string(),[{recursive,boolean()}]}]}]}.
 ```
 
-Disable or enable recursive compiling on for extra src dirs:
+Disable or enable recursive compiling on for `extra_src_dirs`:
 
 ```erlang
+{extra_src_dirs, [{"test", [{recursive, true | false}]}]}
+%% or
 {erl_opts, [{extra_src_dirs,[{string(),[{recursive,boolean()}]}]}]}.
 ```
 

--- a/content/en/docs/running_tests.md
+++ b/content/en/docs/running_tests.md
@@ -58,7 +58,7 @@ To run `common_test` suites:
 $ rebar3 ct 
 ```
 
-Rebar3 will look in all your applications' `test` directories and compile and run any source files named `*_SUITE.erl`.
+Rebar3 will look in all your applications' `test` directories and compile and run any source files named `*_SUITE.erl`. Unlike regular source directories, the compilation of test modules will **not** be recursive by default in order to avoid issues with files in [data directories](https://erlang.org/doc/apps/common_test/write_test_chapter.html#data-and-private-directories). This behaviour [can however be turned on manually with the right compilation options](/docs/configuration#enabledisable-recursive-compiling).
 
 To run only specific test suites:
 


### PR DESCRIPTION
3.14 makes this crystal clear as a behaviour (by fixing a bunch of
subtle bugs) so we can document it properly where necessary.