### PR TITLE
Add overrides sub-section for dependency versions section

### DIFF
--- a/content/en/docs/dependencies.md
+++ b/content/en/docs/dependencies.md
@@ -110,6 +110,24 @@ For convenience reasons (and because [hex.pm](https://hex.pm) mandates semver) h
 ]}.
 ```
 
+### Overrides
+
+Overrides may be used in case of dependency conflicts. This is particularly useful in case of transistive elixir
+dependencies which use version constraints that rebar3 does not currently support. Below is an example of using
+`overrides` configuration to override the `decimal` version constraint for `myxql` : 
+
+```erlang
+erl_opts, [debug_info]}.
+{deps, [myxql]}.
+{overrides,
+  [
+    {override, myxql,
+      [{deps, [{decimal, "~> 2.0"]}]
+    }
+  ]
+}.
+```
+
 To get the latest version of packages available, call:
 
 ```shell


### PR DESCRIPTION
Figured this would be useful until rebar3 supports all version constraints that mix does, if we ever will support them all. 