### PR TITLE
Fix broken link

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -26,7 +26,7 @@ The official build tool for [Erlang](https://erlang.org).
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}
-{{% blocks/feature icon="fas fa-wrench" title="Develop" url="/docs/getting_started/" %}}
+{{% blocks/feature icon="fas fa-wrench" title="Develop" url="/docs/getting-started/" %}}
 Write, test, and maintain projects the Erlang way.
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
Hi!

This link in the "Develop" section from the [index page](https://rebar3.org/) redirects to a 404, this PR fixes it.

![Screenshot from 2021-01-18 19-49-54](https://user-images.githubusercontent.com/11598866/104905966-7407d880-59c6-11eb-8c51-34f0800de529.png)
