### PR TITLE
Bump to 3.16.0

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -7,7 +7,7 @@ linkTitle = "Rebar3"
 {{< blocks/cover title="rebar3" image_anchor="top" height="min" color="white" >}}
 <div class="mx-auto">
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://s3.amazonaws.com/rebar3/rebar3">
-		Download (v3.15.1) <i class="fas fa-cloud-download-alt ml-2 "></i>
+		Download (v3.16.0) <i class="fas fa-cloud-download-alt ml-2 "></i>
 	</a>
     <a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/getting-started">
 		Getting Started <i class="fas fa-arrow-alt-circle-right ml-2"></i>

--- a/content/en/docs/getting-started.md
+++ b/content/en/docs/getting-started.md
@@ -67,7 +67,7 @@ This will compile a `rebar3` escript to the top level of the `rebar3` directory,
 $ ./rebar3 local install
 ```
 
-Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The five newest major Erlang releases are supported at any given time: if the newest version is OTP-23, building with versions as old as OTP-19 will be supported, and produce an executable that will work with those that follow.
+Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The three newest major Erlang releases are supported at any given time: if the newest version is OTP-24, building with versions as old as OTP-22 will be supported, and produce an executable that will work with those that follow.
 
 ## Creating a New Project
 


### PR DESCRIPTION
This is blocked on manually uploading https://github.com/erlang/rebar3/releases/download/3.16.0/rebar3 to the S3 bucket since I broke the CI script before pushing the rebar3 tag yesterday.