### PR TITLE
Fix rebar3 version that support default values

### DIFF
--- a/content/en/docs/deployment/releases.md
+++ b/content/en/docs/deployment/releases.md
@@ -307,7 +307,7 @@ Starting with Erlang/OTP 21 and Rebar3 3.6.0 the configuration options
 `sys_config_src` and `vm_args_src` are available for explicitly including
 templates that will be rendered at runtime, substituting variables defined
 as `${VARIABLE}` with their equivalent value in the shell environment.
-Since Rebar3 4.0.0, a default value can be optionally set when using variables
+Since Rebar3 3.14.0, a default value can be optionally set when using variables
 by defining them as `${VARIABLE:-DEFAULT}`.
 
 As of Rebar3 3.14.0 the configs will be included if they exist, so only if the


### PR DESCRIPTION
Default values for environment variable replacement has been supported at relx 4.0.0 https://github.com/erlware/relx/pull/759 , and it seems included in rebar3 3.14.0 https://github.com/erlang/rebar3/releases/tag/3.14.0