### PR TITLE
Fix order of arguments for download/4 callback

### DIFF
--- a/content/en/docs/extending/custom_dep_resources.md
+++ b/content/en/docs/extending/custom_dep_resources.md
@@ -30,7 +30,7 @@ The new callback API is defined as follows:
 %% and the following callbacks
 -callback init(type(), rebar_state:t()) -> {ok, resource()}.
 -callback lock(rebar_app_info:t(), resource_state()) -> source().
--callback download(file:filename_all(), rebar_app_info:t(), resource_state(), rebar_state:t()) ->
+-callback download(file:filename_all(), rebar_app_info:t(), rebar_state:t(), resource_state()) ->
     ok | {error, any()}.
 -callback needs_update(rebar_app_info:t(), resource_state()) -> boolean().
 -callback make_vsn(rebar_app_info:t(), resource_state()) ->
@@ -208,7 +208,7 @@ download(TmpDir, SourceTuple, RebarState) ->
   download_(TmpDir, SourceTuple, State).
 
 %% New Version
-download(TmpDir, AppInfo, _ResourceState, RebarState) ->
+download(TmpDir, AppInfo, RebarState, _ResourceState) ->
   %%                            extract source tuple
   download_(TmpDir, rebar_app_info:source(AppInfo), RebarState).
 


### PR DESCRIPTION
Fixes #104

The position of `resource_state` is defined [here](https://github.com/erlang/rebar3/blob/048412ed4593e19097f4fa91747593aac6706afb/apps/rebar/src/rebar_resource_v2.erl#L90).