### PR TITLE
Fix broken link

### DIFF
--- a/content/en/docs/testing/eunit.md
+++ b/content/en/docs/testing/eunit.md
@@ -12,7 +12,7 @@ $ rebar3 eunit
 
 Rebar3 will compile all project modules with the macros `{d, TEST, true}` and `{d, EUNIT, true}` defined so you can safely hide your test code within `-ifdef(TEST).` or `-ifdef(EUNIT).` sections. It will also automatically compile any source files in your application's `test` directory, if present. By default, Rebar3 runs tests by calling `eunit:test([{application, App}])` for each application in your project.
 
-The `eunit` command runs as the `test` profile, by default. See [Profiles](/docs/profiles) for details.
+The `eunit` command runs as the `test` profile, by default. See [Profiles](/docs/configuration/profiles) for details.
 
 For available options and their usage see [Commands](/docs/commands) or:
 


### PR DESCRIPTION
Hi! I've noticed there is a broken link in the Eunit section of the documentation. This should fix it.