### PR TITLE
Fix compiler warnings in test_nif example

### DIFF
--- a/content/en/docs/tutorials/building_c_cpp.md
+++ b/content/en/docs/tutorials/building_c_cpp.md
@@ -43,7 +43,7 @@ Below is a NIF which has a function `repeat` that will take a `pid` and an Erlan
 ```c
 #include "erl_nif.h"
 
-ERL_NIF_TERM
+static ERL_NIF_TERM
 mk_atom(ErlNifEnv* env, const char* atom)
 {
     ERL_NIF_TERM ret;
@@ -56,7 +56,7 @@ mk_atom(ErlNifEnv* env, const char* atom)
     return ret;
 }
 
-ERL_NIF_TERM
+static ERL_NIF_TERM
 mk_error(ErlNifEnv* env, const char* mesg)
 {
     return enif_make_tuple2(env, mk_atom(env, "error"), mk_atom(env, mesg));


### PR DESCRIPTION
Clang issues a couple compilation warnings for these functions since it
knows that they're not accessed outside of test_nif.c. This fixes the
warnings.
