### PR TITLE
Remove _google_news template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}


### PR DESCRIPTION
Because it was removed in Hugo v0.111.0: https://github.com/gohugoio/hugo/releases?q=_google_news&expanded=true

Using Hugo >=v0.111.0 with that template causes `hugo server` to fail.

I'm new to Hugo, but I didn't notice any changes in rendered documentation after that line was deleted.