### PR TITLE
Allow errorless copy-pasting

### DIFF
--- a/content/en/docs/configuration/dependencies.md
+++ b/content/en/docs/configuration/dependencies.md
@@ -38,8 +38,8 @@ Dependencies fit any of the following formats:
   {rebar, {git, "git://github.com/erlang/rebar3.git", {tag, "3.0.0"}}},
   %% Source dependencies (git only) in subdirectories, from version 3.14 onwards
   {rebar, {git_subdir, "git://github.com/erlang/rebar3.git", {branch, "main"}, "subdir"}},
-  {rebar, {git_subdir, "git://github.com/erlang/rebar3.git", {tag, "3.14"}, "sub/dir"},
-  {rebar, {git_subdir, "git://github.com/erlang/rebar3.git", {ref, "aeaefd"}, "dir"}
+  {rebar, {git_subdir, "git://github.com/erlang/rebar3.git", {tag, "3.14"}, "sub/dir"}},
+  {rebar, {git_subdir, "git://github.com/erlang/rebar3.git", {ref, "aeaefd"}, "dir"}}
 ]}.
 ```
 

--- a/content/en/docs/configuration/dependencies.md
+++ b/content/en/docs/configuration/dependencies.md
@@ -29,7 +29,6 @@ Dependencies fit any of the following formats:
   {rebar, "1.0.0", {pkg, rebar_fork}},
   %% Source Dependencies
   {rebar, {git, "git://github.com/erlang/rebar3.git"}},
-  {rebar, {git, "http://github.com/erlang/rebar3.git"}},
   {rebar, {git, "https://github.com/erlang/rebar3.git"}},
   {rebar, {git, "git@github.com:erlang/rebar3.git"}},
   {rebar, {hg, "https://othersite.com/erlang/rebar3"}},


### PR DESCRIPTION
Was looking at a reference for https://github.com/erlang/rebar3/blob/main/rebar.config.sample, came here, and a copy-paste failed.